### PR TITLE
feat(task-3a): dependsOn validation and transactional workflow creation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,11 +12,9 @@ const legacySrcFiles = [
   "src/jobs/EmailNotificationJob.ts",
   "src/jobs/Job.ts",
   "src/jobs/JobFactory.ts",
-  "src/routes/analysisRoutes.ts",
   "src/routes/defaultRoute.ts",
   "src/workers/taskRunner.ts",
   "src/workers/taskWorker.ts",
-  "src/workflows/WorkflowFactory.ts",
 ];
 
 module.exports = tseslint.config(

--- a/interview/manual_test_plan.md
+++ b/interview/manual_test_plan.md
@@ -251,3 +251,124 @@ Revert any edits to `src/workflows/example_workflow.yml` before committing:
 ```bash
 git checkout -- src/workflows/example_workflow.yml
 ```
+
+---
+
+## §Task 3a — Workflow YAML `dependsOn` parsing, validation, transactional creation
+
+**Branch:** `strategy-pattern-refactor`
+**Issue:** [#5](https://github.com/hancrafted/async-worfklow-backend-challenge/issues/5)
+**PRD:** §Task 3 (US5, US6, US7, US8)
+
+### Setup
+
+The `POST /analysis` route still loads `src/workflows/example_workflow.yml`.
+For Task 3a manual verification, temporarily edit it to a 3-step workflow
+with mixed dependencies (revert before committing):
+
+```yaml
+# src/workflows/example_workflow.yml
+name: "example_workflow"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+  - taskType: "analysis"
+    stepNumber: 2
+    dependsOn: [1]
+  - taskType: "notification"
+    stepNumber: 3
+    dependsOn: [1, 2]
+```
+
+```bash
+npm install
+npm start
+# → Server is running at http://localhost:3000
+```
+
+### 1. Happy path — multi-step workflow with the right `waiting` / `queued` mix
+
+```bash
+curl -sS -X POST http://localhost:3000/analysis \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "clientId": "manual-task-3a-happy",
+    "geoJson": {
+      "type": "Polygon",
+      "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]
+    }
+  }'
+# → 202 { "workflowId": "<uuid>", "message": "Workflow created..." }
+```
+
+Verify in the DB:
+
+```bash
+sqlite3 data/database.sqlite \
+  "SELECT taskId, stepNumber, status, dependsOn FROM tasks ORDER BY stepNumber;"
+# → step 1: status='queued',  dependsOn='[]'
+# → step 2: status='waiting', dependsOn=JSON UUID array of length 1
+# → step 3: status='waiting', dependsOn=JSON UUID array of length 2
+sqlite3 data/database.sqlite "SELECT workflowId, status FROM workflows;"
+# → status='initial'
+```
+
+> **3a scope note:** `waiting` tasks sit unrun until 3b-ii ships runtime
+> promotion. After ~5s the `polygonArea` step (`queued`) completes and writes
+> a `Result`; steps 2/3 stay `waiting`. That is correct for this slice.
+
+### 2. Sad paths — invalid graphs return 400 with no DB writes
+
+For each error path: copy a fixture YAML over the example, restart the
+server (so the schema is fresh), POST, and verify the unified error shape
+**plus** zero rows in `workflows` / `tasks`.
+
+| Fixture (copy to `src/workflows/example_workflow.yml`) | Expected `error` |
+| --- | --- |
+| `tests/03-interdependent-tasks/fixtures/missing-step-ref.yml` | `INVALID_DEPENDENCY` — `Step 2 references non-existent step 9` |
+| `tests/03-interdependent-tasks/fixtures/cycle-2-3-2.yml` | `DEPENDENCY_CYCLE` — `Cycle detected: 2 → 3 → 2` (rotation may vary) |
+| `tests/03-interdependent-tasks/fixtures/self-dep.yml` | `DEPENDENCY_CYCLE` — `Cycle detected: 1 → 1` |
+| `tests/03-interdependent-tasks/fixtures/duplicate-step.yml` | `INVALID_WORKFLOW_FILE` — `Duplicate stepNumber: 1` |
+| `tests/03-interdependent-tasks/fixtures/missing-tasktype.yml` | `INVALID_WORKFLOW_FILE` — `Step 1 is missing taskType` |
+| `tests/03-interdependent-tasks/fixtures/unknown-tasktype.yml` | `INVALID_WORKFLOW_FILE` — `Step 1 has unknown taskType 'doesNotExist'` |
+
+```bash
+cp tests/03-interdependent-tasks/fixtures/cycle-2-3-2.yml src/workflows/example_workflow.yml
+# restart npm start so AppDataSource drops the schema fresh
+curl -sS -X POST http://localhost:3000/analysis \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "clientId": "manual-task-3a-cycle",
+    "geoJson": { "type": "Polygon", "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]] }
+  }'
+# → 400 { "error": "DEPENDENCY_CYCLE", "message": "Cycle detected: 2 → 3 → 2" }
+sqlite3 data/database.sqlite "SELECT COUNT(*) FROM workflows;"
+# → 0
+sqlite3 data/database.sqlite "SELECT COUNT(*) FROM tasks;"
+# → 0
+```
+
+### 3. Sad paths — request body validation (retrofitted 400s)
+
+```bash
+# missing clientId
+curl -sS -X POST http://localhost:3000/analysis \
+  -H 'Content-Type: application/json' \
+  -d '{ "geoJson": { "type": "Polygon", "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]] } }'
+# → 400 { "error": "INVALID_PAYLOAD", "message": "Request body is missing required `clientId`" }
+
+# missing geoJson
+curl -sS -X POST http://localhost:3000/analysis \
+  -H 'Content-Type: application/json' \
+  -d '{ "clientId": "manual-no-geojson" }'
+# → 400 { "error": "INVALID_PAYLOAD", "message": "Request body is missing required `geoJson`" }
+
+sqlite3 data/database.sqlite "SELECT COUNT(*) FROM workflows;"  # → 0
+sqlite3 data/database.sqlite "SELECT COUNT(*) FROM tasks;"      # → 0
+```
+
+### 4. Cleanup
+
+```bash
+git checkout -- src/workflows/example_workflow.yml
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "marked": "^15.0.3",
         "reflect-metadata": "^0.2.2",
         "sqlite3": "^5.1.7",
-        "typeorm": "^0.3.20"
+        "typeorm": "^0.3.20",
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -24,10 +25,13 @@
         "@types/js-yaml": "^4.0.9",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^22.10.1",
+        "@types/supertest": "^7.2.0",
+        "@types/uuid": "^10.0.0",
         "eslint": "^10.2.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "nodemon": "^3.1.7",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.59.1",
@@ -880,6 +884,19 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -902,6 +919,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3529,6 +3556,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-voronoi": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
@@ -3605,6 +3639,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -3652,6 +3693,37 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -4359,6 +4431,13 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4368,6 +4447,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4555,33 +4641,33 @@
         "node": ">= 10"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.0.tgz",
-      "integrity": "sha512-CCKAP2tkPau7D3GE8+V8R6sQubA9R5foIzGp+85EXCVSCivuxBNAWqcpn72PKYiIcqoViv/kcUDpaEIMBVi1lQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -4845,10 +4931,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4902,6 +5011,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4992,20 +5108,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -5038,6 +5148,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -5059,11 +5180,12 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
       },
@@ -5186,6 +5308,34 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -5588,6 +5738,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5697,6 +5854,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5829,24 +6021,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.5.tgz",
-      "integrity": "sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "dunder-proto": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/github-from-package": {
@@ -5911,21 +6119,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -6833,6 +7046,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -7313,9 +7535,10 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8004,22 +8227,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8057,14 +8264,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8409,6 +8671,106 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -8968,6 +9330,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -9111,15 +9486,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "marked": "^15.0.3",
     "reflect-metadata": "^0.2.2",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -27,10 +28,13 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.10.1",
+    "@types/supertest": "^7.2.0",
+    "@types/uuid": "^10.0.0",
     "eslint": "^10.2.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "nodemon": "^3.1.7",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.59.1",

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -28,6 +28,9 @@ export class Task {
     @Column({ default: 1 })
     stepNumber!: number;
 
+    @Column({ type: 'simple-json', default: '[]' })
+    dependsOn!: string[];
+
     @ManyToOne(() => Workflow, workflow => workflow.tasks)
     workflow!: Workflow;
 }

--- a/src/models/Workflow.ts
+++ b/src/models/Workflow.ts
@@ -1,6 +1,12 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 import { Task } from './Task';
-import {WorkflowStatus} from "../workflows/WorkflowFactory";
+
+export enum WorkflowStatus {
+    Initial = 'initial',
+    InProgress = 'in_progress',
+    Completed = 'completed',
+    Failed = 'failed'
+}
 
 @Entity({ name: 'workflows' })
 export class Workflow {

--- a/src/routes/analysisRoutes.ts
+++ b/src/routes/analysisRoutes.ts
@@ -1,26 +1,92 @@
 import { Router } from 'express';
-import { AppDataSource } from '../data-source';
-import { WorkflowFactory } from '../workflows/WorkflowFactory'; // Create a folder for factories if you prefer
 import path from 'path';
+import * as yaml from 'js-yaml';
+import type { DataSource } from 'typeorm';
+import { AppDataSource } from '../data-source';
+import {
+    WorkflowFactory,
+    WorkflowValidationError,
+} from '../workflows/WorkflowFactory';
+import { ApiErrorCode, errorResponse } from '../utils/errorResponse';
 
-const router = Router();
-const workflowFactory = new WorkflowFactory(AppDataSource);
+interface CreateAnalysisRouterOptions {
+    dataSource: DataSource;
+    workflowFile: string;
+}
 
-router.post('/', async (req, res) => {
-    const { clientId, geoJson } = req.body;
-    const workflowFile = path.join(__dirname, '../workflows/example_workflow.yml');
+/**
+ * Builds a `/analysis` router bound to a specific DataSource and workflow
+ * YAML path. The default export wires up production defaults so callers like
+ * `index.ts` keep `app.use("/analysis", analysisRoutes)` unchanged; tests use
+ * `createAnalysisRouter({ dataSource, workflowFile })` to inject fixtures.
+ */
+export function createAnalysisRouter(
+    options: CreateAnalysisRouterOptions,
+): Router {
+    const router = Router();
+    const factory = new WorkflowFactory(options.dataSource);
 
-    try {
-        const workflow = await workflowFactory.createWorkflowFromYAML(workflowFile, clientId, JSON.stringify(geoJson));
+    router.post('/', async (req, res) => {
+        const { clientId, geoJson } = (req.body ?? {}) as {
+            clientId?: unknown;
+            geoJson?: unknown;
+        };
 
-        res.status(202).json({
-            workflowId: workflow.workflowId,
-            message: 'Workflow created and tasks queued from YAML definition.'
-        });
-    } catch (error: any) {
-        console.error('Error creating workflow:', error);
-        res.status(500).json({ message: 'Failed to create workflow' });
-    }
+        if (typeof clientId !== 'string' || clientId.length === 0) {
+            errorResponse(
+                res,
+                400,
+                ApiErrorCode.INVALID_PAYLOAD,
+                'Request body is missing required `clientId`',
+            );
+            return;
+        }
+        if (geoJson === undefined || geoJson === null) {
+            errorResponse(
+                res,
+                400,
+                ApiErrorCode.INVALID_PAYLOAD,
+                'Request body is missing required `geoJson`',
+            );
+            return;
+        }
+
+        try {
+            const workflow = await factory.createWorkflowFromYAML(
+                options.workflowFile,
+                clientId,
+                JSON.stringify(geoJson),
+            );
+            res.status(202).json({
+                workflowId: workflow.workflowId,
+                message:
+                    'Workflow created and tasks queued from YAML definition.',
+            });
+        } catch (error) {
+            if (error instanceof WorkflowValidationError) {
+                errorResponse(res, 400, error.code, error.message);
+                return;
+            }
+            if (error instanceof yaml.YAMLException) {
+                errorResponse(
+                    res,
+                    400,
+                    ApiErrorCode.INVALID_WORKFLOW_FILE,
+                    `Workflow YAML failed to parse: ${error.message}`,
+                );
+                return;
+            }
+            console.error('Error creating workflow:', error);
+            res.status(500).json({ message: 'Failed to create workflow' });
+        }
+    });
+
+    return router;
+}
+
+const defaultRouter = createAnalysisRouter({
+    dataSource: AppDataSource,
+    workflowFile: path.join(__dirname, '../workflows/example_workflow.yml'),
 });
 
-export default router;
+export default defaultRouter;

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -1,0 +1,25 @@
+import type { Response } from "express";
+
+/**
+ * Unified API error code catalogue. Per the CLAUDE.md style guide, callers
+ * must use this enum rather than magic strings. Tasks 5/6 will extend with
+ * `WORKFLOW_NOT_FOUND` / `WORKFLOW_NOT_TERMINAL` per PRD decision 13.
+ */
+export enum ApiErrorCode {
+  INVALID_PAYLOAD = "INVALID_PAYLOAD",
+  INVALID_WORKFLOW_FILE = "INVALID_WORKFLOW_FILE",
+  INVALID_DEPENDENCY = "INVALID_DEPENDENCY",
+  DEPENDENCY_CYCLE = "DEPENDENCY_CYCLE",
+}
+
+/**
+ * Emits the unified `{ error, message }` API error shape.
+ */
+export function errorResponse(
+  res: Response,
+  status: number,
+  code: ApiErrorCode,
+  message: string,
+): Response {
+  return res.status(status).json({ error: code, message });
+}

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -8,9 +8,11 @@ import { serializeJobError } from '../utils/serializeJobError';
 
 export enum TaskStatus {
     Queued = 'queued',
+    Waiting = 'waiting',
     InProgress = 'in_progress',
     Completed = 'completed',
-    Failed = 'failed'
+    Failed = 'failed',
+    Skipped = 'skipped'
 }
 
 export class TaskRunner {

--- a/src/workflows/WorkflowFactory.ts
+++ b/src/workflows/WorkflowFactory.ts
@@ -1,62 +1,148 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { DataSource } from 'typeorm';
-import { Workflow } from '../models/Workflow';
+import { v4 as uuid } from 'uuid';
+import type { DataSource } from 'typeorm';
+import { Workflow, WorkflowStatus } from '../models/Workflow';
 import { Task } from '../models/Task';
-import {TaskStatus} from "../workers/taskRunner";
+import { TaskStatus } from '../workers/taskRunner';
+import { ApiErrorCode } from '../utils/errorResponse';
+import {
+    validateWorkflowSteps,
+} from './dependencyValidator';
 
-export enum WorkflowStatus {
-    Initial = 'initial',
-    InProgress = 'in_progress',
-    Completed = 'completed',
-    Failed = 'failed'
-}
+export { WorkflowStatus };
 
-interface WorkflowStep {
-    taskType: string;
-    stepNumber: number;
-}
+/**
+ * Thrown by `WorkflowFactory.createWorkflowFromYAML` when the YAML payload
+ * cannot be persisted because of a validation rule from PRD decision 3. The
+ * `code` field maps 1:1 onto the `ApiErrorCode` enum so route handlers can
+ * forward it via `errorResponse(...)` without remapping.
+ */
+export class WorkflowValidationError extends Error {
+    public readonly code: ApiErrorCode;
 
-interface WorkflowDefinition {
-    name: string;
-    steps: WorkflowStep[];
+    constructor(code: ApiErrorCode, message: string) {
+        super(message);
+        this.name = 'WorkflowValidationError';
+        this.code = code;
+    }
 }
 
 export class WorkflowFactory {
     constructor(private dataSource: DataSource) {}
 
     /**
-     * Creates a workflow by reading a YAML file and constructing the Workflow and Task entities.
-     * @param filePath - Path to the YAML file.
-     * @param clientId - Client identifier for the workflow.
-     * @param geoJson - The geoJson data string for tasks (customize as needed).
-     * @returns A promise that resolves to the created Workflow.
+     * Parses the YAML, validates fully in memory, mints UUIDs app-side, and
+     * persists the workflow + all tasks atomically inside a single
+     * `dataSource.transaction(...)`. Either the caller gets a fully-formed
+     * workflow back (success) or a `WorkflowValidationError` (no DB writes).
      */
-    async createWorkflowFromYAML(filePath: string, clientId: string, geoJson: string): Promise<Workflow> {
+    async createWorkflowFromYAML(
+        filePath: string,
+        clientId: string,
+        geoJson: string,
+    ): Promise<Workflow> {
+        // declare
         const fileContent = fs.readFileSync(filePath, 'utf8');
-        const workflowDef = yaml.load(fileContent) as WorkflowDefinition;
-        const workflowRepository = this.dataSource.getRepository(Workflow);
-        const taskRepository = this.dataSource.getRepository(Task);
-        const workflow = new Workflow();
+        let parsed: unknown;
+        try {
+            parsed = yaml.load(fileContent);
+        } catch (error) {
+            throw new WorkflowValidationError(
+                ApiErrorCode.INVALID_WORKFLOW_FILE,
+                `Workflow YAML failed to parse: ${(error as Error).message}`,
+            );
+        }
 
+        // validate
+        const validationError = this.validate(parsed);
+        if (validationError) {
+            throw new WorkflowValidationError(
+                validationError.code,
+                validationError.message,
+            );
+        }
+
+        // perform main logic — at this point validate() has narrowed to steps
+        const steps = (parsed as { steps: unknown }).steps;
+        const validation = validateWorkflowSteps(steps);
+        if (!validation.steps) {
+            throw new WorkflowValidationError(
+                validation.finding.code,
+                validation.finding.message,
+            );
+        }
+        const normalisedSteps = validation.steps;
+
+        const stepNumberToTaskId = new Map<number, string>();
+        for (const step of normalisedSteps) {
+            stepNumberToTaskId.set(step.stepNumber, uuid());
+        }
+
+        const workflowId = uuid();
+        const workflow = new Workflow();
+        workflow.workflowId = workflowId;
         workflow.clientId = clientId;
         workflow.status = WorkflowStatus.Initial;
 
-        const savedWorkflow = await workflowRepository.save(workflow);
-
-        const tasks: Task[] = workflowDef.steps.map(step => {
+        const tasks: Task[] = normalisedSteps.map((step) => {
             const task = new Task();
+            const resolvedTaskId = stepNumberToTaskId.get(step.stepNumber);
+            if (!resolvedTaskId) {
+                throw new Error(
+                    `internal: stepNumber ${step.stepNumber} missing from id map`,
+                );
+            }
+            task.taskId = resolvedTaskId;
             task.clientId = clientId;
             task.geoJson = geoJson;
-            task.status = TaskStatus.Queued;
             task.taskType = step.taskType;
             task.stepNumber = step.stepNumber;
-            task.workflow = savedWorkflow;
+            task.dependsOn = step.dependsOn.map((dep) => {
+                const resolved = stepNumberToTaskId.get(dep);
+                if (!resolved) {
+                    throw new Error(
+                        `internal: stepNumber ${dep} missing from id map`,
+                    );
+                }
+                return resolved;
+            });
+            task.status =
+                task.dependsOn.length === 0
+                    ? TaskStatus.Queued
+                    : TaskStatus.Waiting;
+            task.workflow = workflow;
             return task;
         });
 
-        await taskRepository.save(tasks);
+        // side effects — single atomic transaction (PRD decision 9).
+        await this.dataSource.transaction(async (manager) => {
+            await manager.getRepository(Workflow).save(workflow);
+            await manager.getRepository(Task).save(tasks);
+        });
 
-        return savedWorkflow;
+        return workflow;
+    }
+
+    /**
+     * Pure in-memory validation — no DB. Returns null on success or a
+     * `{ code, message }` finding for the first rule violated. Wraps
+     * `validateWorkflowSteps` so the public surface stays simple.
+     */
+    private validate(
+        parsed: unknown,
+    ): { code: ApiErrorCode; message: string } | null {
+        if (
+            parsed === null ||
+            typeof parsed !== 'object' ||
+            !('steps' in parsed)
+        ) {
+            return {
+                code: ApiErrorCode.INVALID_WORKFLOW_FILE,
+                message: 'Workflow YAML must define a top-level `steps` array',
+            };
+        }
+        const result = validateWorkflowSteps(parsed.steps);
+        return result.finding;
     }
 }

--- a/src/workflows/WorkflowFactory.ts
+++ b/src/workflows/WorkflowFactory.ts
@@ -8,9 +8,19 @@ import { TaskStatus } from '../workers/taskRunner';
 import { ApiErrorCode } from '../utils/errorResponse';
 import {
     validateWorkflowSteps,
+    type NormalisedStep,
+    type ValidationFinding,
 } from './dependencyValidator';
 
 export { WorkflowStatus };
+
+type ParseOutcome =
+    | { parsed: unknown; finding: null }
+    | { parsed: null; finding: ValidationFinding };
+
+type NormalisedOutcome =
+    | { steps: NormalisedStep[]; finding: null }
+    | { steps: null; finding: ValidationFinding };
 
 /**
  * Thrown by `WorkflowFactory.createWorkflowFromYAML` when the YAML payload
@@ -36,77 +46,104 @@ export class WorkflowFactory {
      * persists the workflow + all tasks atomically inside a single
      * `dataSource.transaction(...)`. Either the caller gets a fully-formed
      * workflow back (success) or a `WorkflowValidationError` (no DB writes).
+     *
+     * Body is intentionally an orchestrator: each phase is a named helper so
+     * the sequence (parse → validate → mint ids → build entities → persist)
+     * reads top-to-bottom.
      */
     async createWorkflowFromYAML(
         filePath: string,
         clientId: string,
         geoJson: string,
     ): Promise<Workflow> {
-        // declare
+        const parsing = this.parseYamlFile(filePath);
+        if (parsing.finding) throw new WorkflowValidationError(parsing.finding.code, parsing.finding.message);
+        const validation = this.validateAndNormalize(parsing.parsed);
+        if (validation.finding) throw new WorkflowValidationError(validation.finding.code, validation.finding.message);
+        const stepIdByNumber = this.mintTaskIds(validation.steps);
+        const workflow = this.buildWorkflow(clientId);
+        const tasks = this.buildTasks(validation.steps, stepIdByNumber, workflow, { clientId, geoJson });
+        await this.persistAtomically(workflow, tasks);
+        return workflow;
+    }
+
+    /**
+     * Reads the YAML file from disk and parses it. Returns `{ parsed }` on
+     * success or `{ finding }` on parse failure — never throws (the
+     * orchestrator is the only thrower per CLAUDE.md §Functions).
+     */
+    private parseYamlFile(filePath: string): ParseOutcome {
         const fileContent = fs.readFileSync(filePath, 'utf8');
-        let parsed: unknown;
         try {
-            parsed = yaml.load(fileContent);
+            return { parsed: yaml.load(fileContent), finding: null };
         } catch (error) {
-            throw new WorkflowValidationError(
-                ApiErrorCode.INVALID_WORKFLOW_FILE,
-                `Workflow YAML failed to parse: ${(error as Error).message}`,
-            );
+            return {
+                parsed: null,
+                finding: {
+                    code: ApiErrorCode.INVALID_WORKFLOW_FILE,
+                    message: `Workflow YAML failed to parse: ${(error as Error).message}`,
+                },
+            };
         }
+    }
 
-        // validate
-        const validationError = this.validate(parsed);
-        if (validationError) {
-            throw new WorkflowValidationError(
-                validationError.code,
-                validationError.message,
-            );
+    /**
+     * Pure in-memory validation — no DB. Checks the top-level shape, then
+     * delegates the per-step rules to `validateWorkflowSteps`. Returns the
+     * normalised steps on success or the first finding encountered.
+     */
+    private validateAndNormalize(parsed: unknown): NormalisedOutcome {
+        if (parsed === null || typeof parsed !== 'object' || !('steps' in parsed)) {
+            return {
+                steps: null,
+                finding: {
+                    code: ApiErrorCode.INVALID_WORKFLOW_FILE,
+                    message: 'Workflow YAML must define a top-level `steps` array',
+                },
+            };
         }
+        return validateWorkflowSteps(parsed.steps);
+    }
 
-        // perform main logic — at this point validate() has narrowed to steps
-        const steps = (parsed as { steps: unknown }).steps;
-        const validation = validateWorkflowSteps(steps);
-        if (!validation.steps) {
-            throw new WorkflowValidationError(
-                validation.finding.code,
-                validation.finding.message,
-            );
+    /** Mints a fresh task UUID for every step, keyed by `stepNumber`. */
+    private mintTaskIds(steps: NormalisedStep[]): Map<number, string> {
+        const stepIdByNumber = new Map<number, string>();
+        for (const step of steps) {
+            stepIdByNumber.set(step.stepNumber, uuid());
         }
-        const normalisedSteps = validation.steps;
+        return stepIdByNumber;
+    }
 
-        const stepNumberToTaskId = new Map<number, string>();
-        for (const step of normalisedSteps) {
-            stepNumberToTaskId.set(step.stepNumber, uuid());
-        }
-
-        const workflowId = uuid();
+    /** Builds the unsaved `Workflow` aggregate root in the `Initial` state. */
+    private buildWorkflow(clientId: string): Workflow {
         const workflow = new Workflow();
-        workflow.workflowId = workflowId;
+        workflow.workflowId = uuid();
         workflow.clientId = clientId;
         workflow.status = WorkflowStatus.Initial;
+        return workflow;
+    }
 
-        const tasks: Task[] = normalisedSteps.map((step) => {
+    /**
+     * Builds the unsaved `Task` entities, resolving `dependsOn` step numbers
+     * to the freshly-minted task IDs. A task with no dependencies starts
+     * `Queued`; otherwise it starts `Waiting` and the worker promotes it.
+     */
+    private buildTasks(
+        steps: NormalisedStep[],
+        stepIdByNumber: Map<number, string>,
+        workflow: Workflow,
+        context: { clientId: string; geoJson: string },
+    ): Task[] {
+        return steps.map((step) => {
             const task = new Task();
-            const resolvedTaskId = stepNumberToTaskId.get(step.stepNumber);
-            if (!resolvedTaskId) {
-                throw new Error(
-                    `internal: stepNumber ${step.stepNumber} missing from id map`,
-                );
-            }
-            task.taskId = resolvedTaskId;
-            task.clientId = clientId;
-            task.geoJson = geoJson;
+            task.taskId = this.requireTaskId(stepIdByNumber, step.stepNumber);
+            task.clientId = context.clientId;
+            task.geoJson = context.geoJson;
             task.taskType = step.taskType;
             task.stepNumber = step.stepNumber;
-            task.dependsOn = step.dependsOn.map((dep) => {
-                const resolved = stepNumberToTaskId.get(dep);
-                if (!resolved) {
-                    throw new Error(
-                        `internal: stepNumber ${dep} missing from id map`,
-                    );
-                }
-                return resolved;
-            });
+            task.dependsOn = step.dependsOn.map((dep) =>
+                this.requireTaskId(stepIdByNumber, dep),
+            );
             task.status =
                 task.dependsOn.length === 0
                     ? TaskStatus.Queued
@@ -114,35 +151,34 @@ export class WorkflowFactory {
             task.workflow = workflow;
             return task;
         });
+    }
 
-        // side effects — single atomic transaction (PRD decision 9).
+    /**
+     * Defensive lookup — `validateWorkflowSteps` already guarantees every
+     * `dependsOn` reference resolves, so a miss here is an invariant
+     * violation, not a user-facing validation error.
+     */
+    private requireTaskId(
+        stepIdByNumber: Map<number, string>,
+        stepNumber: number,
+    ): string {
+        const taskId = stepIdByNumber.get(stepNumber);
+        if (!taskId) {
+            throw new Error(
+                `internal: stepNumber ${stepNumber} missing from id map`,
+            );
+        }
+        return taskId;
+    }
+
+    /** Single atomic transaction (PRD decision 9): all-or-nothing persist. */
+    private async persistAtomically(
+        workflow: Workflow,
+        tasks: Task[],
+    ): Promise<void> {
         await this.dataSource.transaction(async (manager) => {
             await manager.getRepository(Workflow).save(workflow);
             await manager.getRepository(Task).save(tasks);
         });
-
-        return workflow;
-    }
-
-    /**
-     * Pure in-memory validation — no DB. Returns null on success or a
-     * `{ code, message }` finding for the first rule violated. Wraps
-     * `validateWorkflowSteps` so the public surface stays simple.
-     */
-    private validate(
-        parsed: unknown,
-    ): { code: ApiErrorCode; message: string } | null {
-        if (
-            parsed === null ||
-            typeof parsed !== 'object' ||
-            !('steps' in parsed)
-        ) {
-            return {
-                code: ApiErrorCode.INVALID_WORKFLOW_FILE,
-                message: 'Workflow YAML must define a top-level `steps` array',
-            };
-        }
-        const result = validateWorkflowSteps(parsed.steps);
-        return result.finding;
     }
 }

--- a/src/workflows/dependencyValidator.ts
+++ b/src/workflows/dependencyValidator.ts
@@ -1,0 +1,172 @@
+import { ApiErrorCode } from "../utils/errorResponse";
+
+/**
+ * Pure in-memory validation for a parsed workflow definition. No DB, no I/O.
+ * Returns `null` on success or a structured error object that the caller
+ * (`WorkflowFactory`) translates into a thrown `WorkflowValidationError`.
+ */
+
+export interface DependencyNode {
+  stepNumber: number;
+  dependsOn: number[];
+}
+
+export interface ValidationFinding {
+  code: ApiErrorCode;
+  message: string;
+}
+
+const KNOWN_TASK_TYPES = new Set(["analysis", "notification", "polygonArea"]);
+
+/**
+ * Tarjan-style DFS cycle finder. Returns the closing path
+ * (`[start, ..., start]`) for the first cycle hit, or `null` if the graph is
+ * a DAG. Self-dependencies are reported as `[n, n]`.
+ */
+export function detectDependencyCycle(
+  nodes: DependencyNode[],
+): number[] | null {
+  const adjacency = new Map<number, number[]>();
+  for (const node of nodes) {
+    adjacency.set(node.stepNumber, [...node.dependsOn]);
+  }
+
+  const VISITING = 1;
+  const VISITED = 2;
+  const state = new Map<number, number>();
+  const stack: number[] = [];
+  let cyclePath: number[] | null = null;
+
+  const visit = (current: number): boolean => {
+    if (state.get(current) === VISITED) return false;
+    if (state.get(current) === VISITING) {
+      const start = stack.indexOf(current);
+      cyclePath = [...stack.slice(start), current];
+      return true;
+    }
+    state.set(current, VISITING);
+    stack.push(current);
+    for (const neighbour of adjacency.get(current) ?? []) {
+      if (visit(neighbour)) return true;
+    }
+    stack.pop();
+    state.set(current, VISITED);
+    return false;
+  };
+
+  for (const node of nodes) {
+    if (visit(node.stepNumber)) return cyclePath;
+  }
+  return null;
+}
+
+interface RawStep {
+  taskType?: unknown;
+  stepNumber?: unknown;
+  dependsOn?: unknown;
+}
+
+export interface NormalisedStep {
+  taskType: string;
+  stepNumber: number;
+  dependsOn: number[];
+}
+
+/**
+ * Validates the parsed YAML's `steps` array. On success returns the
+ * normalised steps; on failure returns the first finding encountered. Order
+ * matches PRD decision 3: shape → duplicates → unknown taskType → missing-ref
+ * → cycle.
+ */
+type ValidationOutcome =
+  | { steps: NormalisedStep[]; finding: null }
+  | { steps: null; finding: ValidationFinding };
+
+const wrongFile = (message: string): ValidationFinding => ({
+  code: ApiErrorCode.INVALID_WORKFLOW_FILE,
+  message,
+});
+
+function checkStepShape(raw: RawStep): ValidationFinding | null {
+  if (typeof raw.stepNumber !== "number" || !Number.isInteger(raw.stepNumber)) {
+    return wrongFile(`Step is missing or has non-integer stepNumber: ${JSON.stringify(raw.stepNumber)}`);
+  }
+  if (typeof raw.taskType !== "string" || raw.taskType.length === 0) {
+    return wrongFile(`Step ${raw.stepNumber} is missing taskType`);
+  }
+  if (!KNOWN_TASK_TYPES.has(raw.taskType)) {
+    return wrongFile(`Step ${raw.stepNumber} has unknown taskType '${raw.taskType}'`);
+  }
+  return null;
+}
+
+function normaliseDependsOn(
+  raw: RawStep,
+  stepNumber: number,
+): { dependsOn: number[]; finding: null } | { dependsOn: null; finding: ValidationFinding } {
+  if (raw.dependsOn === undefined) return { dependsOn: [], finding: null };
+  if (!Array.isArray(raw.dependsOn)) {
+    return { dependsOn: null, finding: wrongFile(`Step ${stepNumber} dependsOn must be an array of step numbers`) };
+  }
+  const dependsOn: number[] = [];
+  for (const entry of raw.dependsOn as unknown[]) {
+    if (typeof entry !== "number" || !Number.isInteger(entry)) {
+      return { dependsOn: null, finding: wrongFile(`Step ${stepNumber} dependsOn must contain only integer step numbers`) };
+    }
+    dependsOn.push(entry);
+  }
+  return { dependsOn, finding: null };
+}
+
+function normaliseStep(
+  raw: RawStep,
+  seen: Set<number>,
+): { step: NormalisedStep; finding: null } | { step: null; finding: ValidationFinding } {
+  const shapeFinding = checkStepShape(raw);
+  if (shapeFinding) return { step: null, finding: shapeFinding };
+  const stepNumber = raw.stepNumber as number;
+  if (seen.has(stepNumber)) {
+    return { step: null, finding: wrongFile(`Duplicate stepNumber: ${stepNumber}`) };
+  }
+  const deps = normaliseDependsOn(raw, stepNumber);
+  if (deps.finding) return { step: null, finding: deps.finding };
+  return {
+    step: { taskType: raw.taskType as string, stepNumber, dependsOn: deps.dependsOn },
+    finding: null,
+  };
+}
+
+function checkReferences(
+  normalised: NormalisedStep[],
+  seen: Set<number>,
+): ValidationFinding | null {
+  for (const step of normalised) {
+    for (const dep of step.dependsOn) {
+      if (!seen.has(dep)) {
+        return { code: ApiErrorCode.INVALID_DEPENDENCY, message: `Step ${step.stepNumber} references non-existent step ${dep}` };
+      }
+    }
+  }
+  const cycle = detectDependencyCycle(normalised);
+  if (cycle) {
+    return { code: ApiErrorCode.DEPENDENCY_CYCLE, message: `Cycle detected: ${cycle.join(" → ")}` };
+  }
+  return null;
+}
+
+export function validateWorkflowSteps(steps: unknown): ValidationOutcome {
+  if (!Array.isArray(steps) || steps.length === 0) {
+    return { steps: null, finding: wrongFile("Workflow has no steps") };
+  }
+  const normalised: NormalisedStep[] = [];
+  const seen = new Set<number>();
+  for (const raw of steps as RawStep[]) {
+    const outcome = normaliseStep(raw, seen);
+    if (outcome.finding) return { steps: null, finding: outcome.finding };
+    seen.add(outcome.step.stepNumber);
+    normalised.push(outcome.step);
+  }
+  const refFinding = checkReferences(normalised, seen);
+  if (refFinding) return { steps: null, finding: refFinding };
+  return { steps: normalised, finding: null };
+}

--- a/tests/03-interdependent-tasks/cycle-detector.unit.test.ts
+++ b/tests/03-interdependent-tasks/cycle-detector.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { detectDependencyCycle } from "../../src/workflows/dependencyValidator";
+
+// Cycle detector exercised in pure isolation — no DB, no YAML, no Express.
+// Inputs are step-number → number[] adjacency; output is `null` for a DAG, or
+// the smallest cycle path expressed as `[a, b, ..., a]` for the user-facing
+// `Cycle detected: 2 → 3 → 2` message.
+describe("detectDependencyCycle — pure DAG / cycle / self-dep checker", () => {
+  describe("happy path: returns null for a valid DAG", () => {
+    it("returns null for a strictly linear chain 1 → 2 → 3", () => {
+      // step 1 has no deps; step 2 depends on 1; step 3 depends on 2.
+      const cycle = detectDependencyCycle([
+        { stepNumber: 1, dependsOn: [] },
+        { stepNumber: 2, dependsOn: [1] },
+        { stepNumber: 3, dependsOn: [2] },
+      ]);
+      expect(cycle).toBeNull();
+    });
+
+    it("returns null for a diamond 1 → {2,3} → 4", () => {
+      // Steps 2 and 3 both depend on 1; step 4 joins on both — still acyclic.
+      const cycle = detectDependencyCycle([
+        { stepNumber: 1, dependsOn: [] },
+        { stepNumber: 2, dependsOn: [1] },
+        { stepNumber: 3, dependsOn: [1] },
+        { stepNumber: 4, dependsOn: [2, 3] },
+      ]);
+      expect(cycle).toBeNull();
+    });
+  });
+
+  describe("error path: returns the cycle path for any cycle or self-dep", () => {
+    it("flags a self-dependency 2 → 2 as a cycle [2,2]", () => {
+      const cycle = detectDependencyCycle([
+        { stepNumber: 1, dependsOn: [] },
+        { stepNumber: 2, dependsOn: [2] },
+      ]);
+      expect(cycle).toEqual([2, 2]);
+    });
+
+    it("flags a 2-node cycle 2 → 3 → 2", () => {
+      const cycle = detectDependencyCycle([
+        { stepNumber: 1, dependsOn: [] },
+        { stepNumber: 2, dependsOn: [3] },
+        { stepNumber: 3, dependsOn: [2] },
+      ]);
+      // Either rotation of the cycle is acceptable, but the path must close
+      // (first element repeats at the end) and contain only the cycle nodes.
+      expect(cycle).not.toBeNull();
+      expect(cycle![0]).toBe(cycle![cycle!.length - 1]);
+      expect(new Set(cycle)).toEqual(new Set([2, 3]));
+    });
+
+    it("flags a longer cycle 1 → 2 → 3 → 1", () => {
+      const cycle = detectDependencyCycle([
+        { stepNumber: 1, dependsOn: [3] },
+        { stepNumber: 2, dependsOn: [1] },
+        { stepNumber: 3, dependsOn: [2] },
+      ]);
+      expect(cycle).not.toBeNull();
+      expect(cycle![0]).toBe(cycle![cycle!.length - 1]);
+      expect(new Set(cycle)).toEqual(new Set([1, 2, 3]));
+    });
+  });
+});

--- a/tests/03-interdependent-tasks/dependency-validator.unit.test.ts
+++ b/tests/03-interdependent-tasks/dependency-validator.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { validateWorkflowSteps } from "../../src/workflows/dependencyValidator";
+import { ApiErrorCode } from "../../src/utils/errorResponse";
+
+// Sidecar TDD unit tests for `validateWorkflowSteps`. Each error-code branch
+// of PRD decision 3 is exercised in isolation against the pure validator
+// (no DB, no Express).
+describe("validateWorkflowSteps — in-memory dependency validator", () => {
+  describe("happy path: returns normalised steps for a valid graph", () => {
+    it("normalises a 3-step DAG with mixed dependsOn presence", () => {
+      // Step 1: no deps; Step 2: depends on 1; Step 3: depends on 1 and 2.
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1 },
+        { taskType: "analysis", stepNumber: 2, dependsOn: [1] },
+        { taskType: "notification", stepNumber: 3, dependsOn: [1, 2] },
+      ]);
+      expect(result.finding).toBeNull();
+      expect(result.steps).toEqual([
+        { taskType: "polygonArea", stepNumber: 1, dependsOn: [] },
+        { taskType: "analysis", stepNumber: 2, dependsOn: [1] },
+        { taskType: "notification", stepNumber: 3, dependsOn: [1, 2] },
+      ]);
+    });
+  });
+
+  describe("error path: each PRD-decision-3 rule fires its own code + message", () => {
+    it("rejects a duplicate stepNumber with INVALID_WORKFLOW_FILE and names the offender", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1 },
+        { taskType: "analysis", stepNumber: 1 },
+      ]);
+      expect(result.finding).toEqual({
+        code: ApiErrorCode.INVALID_WORKFLOW_FILE,
+        message: "Duplicate stepNumber: 1",
+      });
+    });
+
+    it("rejects a missing taskType with INVALID_WORKFLOW_FILE", () => {
+      const result = validateWorkflowSteps([{ stepNumber: 1 }]);
+      expect(result.finding?.code).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect(result.finding?.message).toMatch(/missing taskType/);
+    });
+
+    it("rejects an unknown taskType with INVALID_WORKFLOW_FILE", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "doesNotExist", stepNumber: 1 },
+      ]);
+      expect(result.finding?.code).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect(result.finding?.message).toMatch(/unknown taskType/);
+    });
+
+    it("rejects a missing-step reference with INVALID_DEPENDENCY and the offending pair", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1 },
+        { taskType: "analysis", stepNumber: 2, dependsOn: [9] },
+      ]);
+      expect(result.finding).toEqual({
+        code: ApiErrorCode.INVALID_DEPENDENCY,
+        message: "Step 2 references non-existent step 9",
+      });
+    });
+
+    it("rejects a multi-node cycle with DEPENDENCY_CYCLE", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1 },
+        { taskType: "analysis", stepNumber: 2, dependsOn: [3] },
+        { taskType: "notification", stepNumber: 3, dependsOn: [2] },
+      ]);
+      expect(result.finding?.code).toBe(ApiErrorCode.DEPENDENCY_CYCLE);
+      expect(result.finding?.message).toMatch(/Cycle detected:/);
+    });
+
+    it("rejects a self-dependency with DEPENDENCY_CYCLE", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1, dependsOn: [1] },
+      ]);
+      expect(result.finding?.code).toBe(ApiErrorCode.DEPENDENCY_CYCLE);
+      expect(result.finding?.message).toBe("Cycle detected: 1 → 1");
+    });
+
+    it("rejects a non-array dependsOn with INVALID_WORKFLOW_FILE (no scalar shorthand)", () => {
+      const result = validateWorkflowSteps([
+        { taskType: "polygonArea", stepNumber: 1 },
+        { taskType: "analysis", stepNumber: 2, dependsOn: 1 },
+      ]);
+      expect(result.finding?.code).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect(result.finding?.message).toMatch(/must be an array/);
+    });
+  });
+});

--- a/tests/03-interdependent-tasks/error-response.unit.test.ts
+++ b/tests/03-interdependent-tasks/error-response.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Response } from "express";
+import {
+  ApiErrorCode,
+  errorResponse,
+} from "../../src/utils/errorResponse";
+
+// Sidecar TDD unit tests for the errorResponse helper. Asserts the helper
+// emits the unified `{ error, message }` shape and uses the ApiErrorCode enum
+// rather than magic strings.
+describe("errorResponse helper — unified API error response shape", () => {
+  describe("happy path: emits { error, message } with the supplied status", () => {
+    it("calls res.status(400).json({ error: 'INVALID_PAYLOAD', message }) for INVALID_PAYLOAD", () => {
+      const json = vi.fn();
+      const status = vi.fn(() => ({ json }));
+      const res = { status } as unknown as Response;
+
+      errorResponse(res, 400, ApiErrorCode.INVALID_PAYLOAD, "missing clientId");
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({
+        error: "INVALID_PAYLOAD",
+        message: "missing clientId",
+      });
+    });
+
+    it("propagates DEPENDENCY_CYCLE / INVALID_DEPENDENCY / INVALID_WORKFLOW_FILE codes verbatim", () => {
+      // Every ApiErrorCode the helper must support in this slice — exercised
+      // in a single it() to keep the unit table-driven.
+      const codes: Array<[ApiErrorCode, string]> = [
+        [ApiErrorCode.INVALID_DEPENDENCY, "Step 2 references non-existent step 9"],
+        [ApiErrorCode.DEPENDENCY_CYCLE, "Cycle detected: 2 → 3 → 2"],
+        [ApiErrorCode.INVALID_WORKFLOW_FILE, "Duplicate stepNumber: 1"],
+      ];
+      for (const [code, message] of codes) {
+        const json = vi.fn();
+        const status = vi.fn(() => ({ json }));
+        const res = { status } as unknown as Response;
+        errorResponse(res, 400, code, message);
+        expect(status).toHaveBeenCalledWith(400);
+        expect(json).toHaveBeenCalledWith({ error: code, message });
+      }
+    });
+  });
+
+  describe("ApiErrorCode enum — no magic strings", () => {
+    it("exports the four codes this slice introduces", () => {
+      // Locks the enum surface so callers can rely on these constants existing.
+      expect(ApiErrorCode.INVALID_PAYLOAD).toBe("INVALID_PAYLOAD");
+      expect(ApiErrorCode.INVALID_WORKFLOW_FILE).toBe("INVALID_WORKFLOW_FILE");
+      expect(ApiErrorCode.INVALID_DEPENDENCY).toBe("INVALID_DEPENDENCY");
+      expect(ApiErrorCode.DEPENDENCY_CYCLE).toBe("DEPENDENCY_CYCLE");
+    });
+  });
+});

--- a/tests/03-interdependent-tasks/fixtures/cycle-2-3-2.yml
+++ b/tests/03-interdependent-tasks/fixtures/cycle-2-3-2.yml
@@ -1,0 +1,10 @@
+name: "cycle_2_3_2"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+  - taskType: "analysis"
+    stepNumber: 2
+    dependsOn: [3]
+  - taskType: "notification"
+    stepNumber: 3
+    dependsOn: [2]

--- a/tests/03-interdependent-tasks/fixtures/duplicate-step.yml
+++ b/tests/03-interdependent-tasks/fixtures/duplicate-step.yml
@@ -1,0 +1,6 @@
+name: "duplicate_step"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+  - taskType: "analysis"
+    stepNumber: 1

--- a/tests/03-interdependent-tasks/fixtures/missing-step-ref.yml
+++ b/tests/03-interdependent-tasks/fixtures/missing-step-ref.yml
@@ -1,0 +1,7 @@
+name: "missing_step_ref"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+  - taskType: "analysis"
+    stepNumber: 2
+    dependsOn: [9]

--- a/tests/03-interdependent-tasks/fixtures/missing-tasktype.yml
+++ b/tests/03-interdependent-tasks/fixtures/missing-tasktype.yml
@@ -1,0 +1,3 @@
+name: "missing_tasktype"
+steps:
+  - stepNumber: 1

--- a/tests/03-interdependent-tasks/fixtures/self-dep.yml
+++ b/tests/03-interdependent-tasks/fixtures/self-dep.yml
@@ -1,0 +1,5 @@
+name: "self_dep"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+    dependsOn: [1]

--- a/tests/03-interdependent-tasks/fixtures/three-step-mixed-deps.yml
+++ b/tests/03-interdependent-tasks/fixtures/three-step-mixed-deps.yml
@@ -1,0 +1,10 @@
+name: "three_step_mixed_deps"
+steps:
+  - taskType: "polygonArea"
+    stepNumber: 1
+  - taskType: "analysis"
+    stepNumber: 2
+    dependsOn: [1]
+  - taskType: "notification"
+    stepNumber: 3
+    dependsOn: [1, 2]

--- a/tests/03-interdependent-tasks/fixtures/unknown-tasktype.yml
+++ b/tests/03-interdependent-tasks/fixtures/unknown-tasktype.yml
@@ -1,0 +1,4 @@
+name: "unknown_tasktype"
+steps:
+  - taskType: "doesNotExist"
+    stepNumber: 1

--- a/tests/03-interdependent-tasks/tasks-can-be-chained-through-dependencies.test.ts
+++ b/tests/03-interdependent-tasks/tasks-can-be-chained-through-dependencies.test.ts
@@ -1,0 +1,205 @@
+import "reflect-metadata";
+import path from "path";
+import express from "express";
+import request from "supertest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import {
+  WorkflowStatus,
+} from "../../src/workflows/WorkflowFactory";
+import { createAnalysisRouter } from "../../src/routes/analysisRoutes";
+import { ApiErrorCode } from "../../src/utils/errorResponse";
+
+const VALID_GEOJSON = {
+  type: "Polygon",
+  coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+};
+
+const fixture = (name: string): string =>
+  path.join(__dirname, "fixtures", name);
+
+const buildDataSource = (): DataSource =>
+  new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    dropSchema: true,
+    entities: [Task, Result, Workflow],
+    synchronize: true,
+    logging: false,
+  });
+
+const buildApp = (dataSource: DataSource, workflowFile: string): express.Express => {
+  const app = express();
+  app.use(express.json());
+  app.use("/analysis", createAnalysisRouter({ dataSource, workflowFile }));
+  return app;
+};
+
+interface ErrorBody {
+  error: string;
+  message: string;
+}
+
+// Readme §3 R2 — "Tasks can be chained through dependencies."
+// Task 3a covers workflow creation only; the runtime execution chain is added
+// by 3b-ii (TODO: extend the happy-path describe with a "runs in topological
+// order" `it()` once promotion + lifecycle land).
+describe("Readme §3 R2 — tasks can be chained through dependencies (creation slice)", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = buildDataSource();
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource.isInitialized) await dataSource.destroy();
+  });
+
+  describe("happy path: tasks can be chained through dependencies", () => {
+    it("creates a multi-step workflow with the correct waiting / queued mix", async () => {
+      // Submit a 3-step YAML where step 1 has no deps and steps 2 & 3 have
+      // dependsOn. Asserts: 202 { workflowId }, DB shows resolved-UUID
+      // dependsOn, deps-free task starts queued, deps-bearing tasks start
+      // waiting, Workflow.status === 'initial'.
+      const app = buildApp(dataSource, fixture("three-step-mixed-deps.yml"));
+
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-happy", geoJson: VALID_GEOJSON });
+      const body = response.body as { workflowId: string };
+
+      expect(response.status).toBe(202);
+      expect(body).toHaveProperty("workflowId");
+      expect(body.workflowId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+
+      const tasks = await dataSource.getRepository(Task).find({
+        where: { workflow: { workflowId: body.workflowId } },
+        relations: ["workflow"],
+        order: { stepNumber: "ASC" },
+      });
+      expect(tasks).toHaveLength(3);
+      expect(tasks[0].status).toBe(TaskStatus.Queued);
+      expect(tasks[0].dependsOn).toEqual([]);
+      expect(tasks[1].status).toBe(TaskStatus.Waiting);
+      expect(tasks[1].dependsOn).toEqual([tasks[0].taskId]);
+      expect(tasks[2].status).toBe(TaskStatus.Waiting);
+      expect(new Set(tasks[2].dependsOn)).toEqual(
+        new Set([tasks[0].taskId, tasks[1].taskId]),
+      );
+
+      const workflow = await dataSource.getRepository(Workflow).findOneOrFail({
+        where: { workflowId: body.workflowId },
+      });
+      expect(workflow.status).toBe(WorkflowStatus.Initial);
+    });
+  });
+
+  describe("error path: invalid dependency graph rejected at creation time", () => {
+    const assertNoDbWrites = async (): Promise<void> => {
+      expect(await dataSource.getRepository(Workflow).count()).toBe(0);
+      expect(await dataSource.getRepository(Task).count()).toBe(0);
+    };
+
+    it("rejects a missing-step reference with 400 INVALID_DEPENDENCY and writes nothing", async () => {
+      // Step 2 declares dependsOn: [9] but step 9 does not exist. Asserts
+      // unified `{ error, message }` shape AND zero rows in workflows / tasks
+      // tables — the no-DB-writes-on-4xx invariant.
+      const app = buildApp(dataSource, fixture("missing-step-ref.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-missing", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: ApiErrorCode.INVALID_DEPENDENCY,
+        message: "Step 2 references non-existent step 9",
+      });
+      await assertNoDbWrites();
+    });
+
+    it("rejects a multi-node cycle (2 → 3 → 2) with 400 DEPENDENCY_CYCLE", async () => {
+      const app = buildApp(dataSource, fixture("cycle-2-3-2.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-cycle", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.DEPENDENCY_CYCLE);
+      expect((response.body as ErrorBody).message).toMatch(/Cycle detected:/);
+      await assertNoDbWrites();
+    });
+
+    it("rejects a self-dependency (1 → 1) with 400 DEPENDENCY_CYCLE", async () => {
+      const app = buildApp(dataSource, fixture("self-dep.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-self", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: ApiErrorCode.DEPENDENCY_CYCLE,
+        message: "Cycle detected: 1 → 1",
+      });
+      await assertNoDbWrites();
+    });
+
+    it("rejects a duplicate stepNumber with 400 INVALID_WORKFLOW_FILE", async () => {
+      const app = buildApp(dataSource, fixture("duplicate-step.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-dup", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect((response.body as ErrorBody).message).toMatch(/Duplicate stepNumber/);
+      await assertNoDbWrites();
+    });
+
+    it("rejects a missing taskType with 400 INVALID_WORKFLOW_FILE", async () => {
+      const app = buildApp(dataSource, fixture("missing-tasktype.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-no-type", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect((response.body as ErrorBody).message).toMatch(/missing taskType/);
+      await assertNoDbWrites();
+    });
+
+    it("rejects an unknown taskType with 400 INVALID_WORKFLOW_FILE", async () => {
+      const app = buildApp(dataSource, fixture("unknown-tasktype.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-unknown-type", geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.INVALID_WORKFLOW_FILE);
+      expect((response.body as ErrorBody).message).toMatch(/unknown taskType/);
+      await assertNoDbWrites();
+    });
+
+    it("rejects a missing clientId on the request body with 400 INVALID_PAYLOAD", async () => {
+      // Retrofit: existing route accepted absent clientId silently. Now the
+      // route returns the unified 400 shape with INVALID_PAYLOAD.
+      const app = buildApp(dataSource, fixture("three-step-mixed-deps.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ geoJson: VALID_GEOJSON });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.INVALID_PAYLOAD);
+      await assertNoDbWrites();
+    });
+
+    it("rejects a missing geoJson on the request body with 400 INVALID_PAYLOAD", async () => {
+      const app = buildApp(dataSource, fixture("three-step-mixed-deps.yml"));
+      const response = await request(app)
+        .post("/analysis")
+        .send({ clientId: "client-no-geojson" });
+      expect(response.status).toBe(400);
+      expect((response.body as ErrorBody).error).toBe(ApiErrorCode.INVALID_PAYLOAD);
+      await assertNoDbWrites();
+    });
+  });
+});

--- a/tests/03-interdependent-tasks/workflow-factory.unit.test.ts
+++ b/tests/03-interdependent-tasks/workflow-factory.unit.test.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import path from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DataSource } from "typeorm";
+import { Task } from "../../src/models/Task";
+import { Result } from "../../src/models/Result";
+import { Workflow } from "../../src/models/Workflow";
+import { TaskStatus } from "../../src/workers/taskRunner";
+import {
+  WorkflowFactory,
+  WorkflowStatus,
+  WorkflowValidationError,
+} from "../../src/workflows/WorkflowFactory";
+import { ApiErrorCode } from "../../src/utils/errorResponse";
+
+const VALID_GEOJSON = JSON.stringify({
+  type: "Polygon",
+  coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+});
+
+const fixture = (name: string): string =>
+  path.join(__dirname, "fixtures", name);
+
+const buildDataSource = (): DataSource =>
+  new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    dropSchema: true,
+    entities: [Task, Result, Workflow],
+    synchronize: true,
+    logging: false,
+  });
+
+describe("WorkflowFactory — single-pass transactional create", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = buildDataSource();
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource.isInitialized) await dataSource.destroy();
+  });
+
+  describe("happy path: persists workflow + tasks atomically with the right waiting/queued mix", () => {
+    it("inserts deps-free tasks as queued, deps-bearing tasks as waiting, with resolved-UUID dependsOn", async () => {
+      // Builds a 3-step workflow (step 1 deps-free, step 2 deps on 1, step 3
+      // deps on 1 + 2). Asserts each task row carries the right initial
+      // status, that `dependsOn` holds the resolved upstream taskIds (UUIDs),
+      // and that `Workflow.status` defaults to 'initial'.
+      const factory = new WorkflowFactory(dataSource);
+      const workflow = await factory.createWorkflowFromYAML(
+        fixture("three-step-mixed-deps.yml"),
+        "client-happy",
+        VALID_GEOJSON,
+      );
+
+      expect(workflow.workflowId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(workflow.status).toBe(WorkflowStatus.Initial);
+
+      const tasks = await dataSource.getRepository(Task).find({
+        where: { workflow: { workflowId: workflow.workflowId } },
+        relations: ["workflow"],
+        order: { stepNumber: "ASC" },
+      });
+      expect(tasks).toHaveLength(3);
+      expect(tasks[0].status).toBe(TaskStatus.Queued);
+      expect(tasks[0].dependsOn).toEqual([]);
+      expect(tasks[1].status).toBe(TaskStatus.Waiting);
+      expect(tasks[1].dependsOn).toEqual([tasks[0].taskId]);
+      expect(tasks[2].status).toBe(TaskStatus.Waiting);
+      expect(new Set(tasks[2].dependsOn)).toEqual(
+        new Set([tasks[0].taskId, tasks[1].taskId]),
+      );
+    });
+  });
+
+  describe("error path: validation failures throw WorkflowValidationError and write nothing", () => {
+    const fixtures: Array<[string, string, ApiErrorCode]> = [
+      ["missing-step-ref.yml", "missing-step", ApiErrorCode.INVALID_DEPENDENCY],
+      ["cycle-2-3-2.yml", "cycle", ApiErrorCode.DEPENDENCY_CYCLE],
+      ["self-dep.yml", "self-dep", ApiErrorCode.DEPENDENCY_CYCLE],
+      ["duplicate-step.yml", "duplicate", ApiErrorCode.INVALID_WORKFLOW_FILE],
+      ["missing-tasktype.yml", "missing-taskType", ApiErrorCode.INVALID_WORKFLOW_FILE],
+      ["unknown-tasktype.yml", "unknown-taskType", ApiErrorCode.INVALID_WORKFLOW_FILE],
+    ];
+
+    for (const [filename, label, expectedCode] of fixtures) {
+      it(`rejects ${label} with ${expectedCode} and persists no rows`, async () => {
+        const factory = new WorkflowFactory(dataSource);
+        await expect(
+          factory.createWorkflowFromYAML(
+            fixture(filename),
+            "client-bad",
+            VALID_GEOJSON,
+          ),
+        ).rejects.toBeInstanceOf(WorkflowValidationError);
+
+        try {
+          await factory.createWorkflowFromYAML(
+            fixture(filename),
+            "client-bad",
+            VALID_GEOJSON,
+          );
+        } catch (error) {
+          expect((error as WorkflowValidationError).code).toBe(expectedCode);
+        }
+
+        expect(await dataSource.getRepository(Workflow).count()).toBe(0);
+        expect(await dataSource.getRepository(Task).count()).toBe(0);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Closes #5.

## Summary

Ship Task 3a: workflow YAML `dependsOn` parsing, in-memory validation, app-side UUID minting, and transactional persistence. Multi-step workflows now create with the right `waiting` / `queued` mix; invalid graphs return a unified `400 { error, message }` shape with **zero DB writes**. Runtime promotion / fail-fast / lifecycle transitions remain owned by 3b-ii (#7).

## What's in this PR

Single commit `5a5111f`:

- **Schema** — `Task.dependsOn: string[]` (simple-json UUIDs); `TaskStatus` extended with `Waiting` / `Skipped` (declaration only — runtime use is 3b-ii); `Workflow.status` with new `WorkflowStatus` enum (`Initial` / `InProgress` / `Completed` / `Failed`) defaulting to `Initial`.
- **`WorkflowFactory` rewrite** — single-pass per PRD decision 9: parse → in-memory validate → mint `workflowId` + per-step `taskId` UUIDs app-side → build entities with `dependsOn` already resolved → persist atomically inside `dataSource.transaction(...)`.
- **Insertion rule** — deps-free → `queued`; deps-bearing → `waiting`.
- **Validation** with offending-step-number messages:
  - Missing-step ref → `INVALID_DEPENDENCY`
  - Cycle / self-dep → `DEPENDENCY_CYCLE`
  - Duplicate `stepNumber` / missing `taskType` / unknown `taskType` → `INVALID_WORKFLOW_FILE`
- **`errorResponse(res, status, code, message)` helper + `ApiErrorCode` enum** — `POST /analysis` 400 paths now use the unified shape; existing pre-3a 400 paths (malformed YAML, missing `clientId` / `geoJson`) retrofitted to `INVALID_PAYLOAD` / `INVALID_WORKFLOW_FILE`.
- **Route export change** — `createAnalysisRouter(dataSource)` is now exported so integration tests can mount the route against an in-memory SQLite without touching globals.
- **Deps added** — `uuid` (app-side UUID minting), `@types/uuid`, `supertest`, `@types/supertest` (integration tests).

## Test strategy (Option A — confirmed pre-implementation)

Per `CLAUDE.md`'s "exactly one test file per Readme requirement" rule, README §3 has 2 "Requirements" bullets → 2 requirement-fulfilling files in `tests/03-interdependent-tasks/`, populated **incrementally across the four Task 3 sub-slices**:

- `tests/03-interdependent-tasks/tasks-can-be-chained-through-dependencies.test.ts` (Req 2) — **3a writes the first describe blocks here**: 1 happy block (waiting/queued mix on creation; full execution chain reserved for 3b-ii via TODO) + 1 error block (8 `it`s covering the 4 validation codes + the 2 retrofitted `INVALID_PAYLOAD` cases, each with row-count assertions for the no-DB-writes invariant).
- `tests/03-interdependent-tasks/dependent-tasks-wait-for-dependencies-to-complete.test.ts` (Req 1) — **NOT added in this slice**; 3b-ii's territory.

Sidecar TDD unit tests:

- `cycle-detector.unit.test.ts` (5 tests)
- `dependency-validator.unit.test.ts` (8 tests)
- `workflow-factory.unit.test.ts` (7 tests — transactional behavior, no-writes-on-validation-fail)
- `error-response.unit.test.ts` (3 tests)

Final suite: **8 files / 42 tests**, all green. Task 1 tests untouched in observable behavior.

## Verification

```bash
npm ci
npm test            # 8 files / 42 tests passing
npm run lint        # exit 0
npm run typecheck   # exit 0
```

Husky `pre-commit` and `pre-push` hooks ran on the commit and push — no `--no-verify` used.

Manual test plan §Task 3a appended to `interview/manual_test_plan.md` with curl + sqlite verification for the success path and all four 400 paths (each verifying zero rows persisted).

## Design decisions (recorded in `interview/design_decisions.md` §Task 3)

No new pragmatic-vs-production-grade decisions beyond what's already documented in the existing §Task 3 entry. Single-pass transactional creation matches PRD decision 9; app-side UUID minting matches the prepared design.

## Deliberately out of scope (later slices)

- Runtime promotion `waiting → queued` after dependencies complete (#7 — 3b-ii)
- Workflow lifecycle transitions `initial → in_progress`, terminal transitions (#7 — 3b-ii)
- Fail-fast sweep on task failure (#7 — 3b-ii)
- `Job.run({ task, dependencies })` migration (#6 — 3b-i)
- Worker pool + JSON-line logger (#8 — 3c)
- `WORKFLOW_NOT_FOUND` / `WORKFLOW_NOT_TERMINAL` error codes (Tasks 5/6)

## Notes

- The integration error-describe block has **8 `it()` cases** instead of the spec-mandated 5 — broader coverage (cycle vs self-dep split + 2 retrofitted `INVALID_PAYLOAD` cases for the existing `POST /analysis` 400 paths). Documented as a non-blocking deviation; more coverage with the same shape.
- HEAD commit was `git commit --amend`-ed once on the local branch (pre-push) to fold three uncommitted files into the initial commit and replace a truncated commit message. Branch was never pushed before the amend, so no force-push concerns.

## References

- Issue: #5
- PRD §Implementation Decisions 1, 3, 9, 13
- User stories: US5, US6, US7, US8
- `interview/design_decisions.md` §Task 3
- `interview/manual_test_plan.md` §Task 3a
- `Readme.md` §3 "Support Interdependent Tasks in Workflows"

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author