### PR TITLE
refactor(jobs): migrate Job.run to JobContext signature (Task 3b-i, #6)

### DIFF
--- a/interview/manual_test_plan.md
+++ b/interview/manual_test_plan.md
@@ -372,3 +372,72 @@ sqlite3 data/database.sqlite "SELECT COUNT(*) FROM tasks;"      # → 0
 ```bash
 git checkout -- src/workflows/example_workflow.yml
 ```
+
+---
+
+## §Task 3b-i — Migrate `Job.run` to the `JobContext` signature
+
+**Branch:** `migrate-job.run-to-jobcontext`
+**Issue:** [#6](https://github.com/hancrafted/async-worfklow-backend-challenge/issues/6)
+**PRD:** §Implementation Decision 5
+
+### Setup
+
+This task is a pure signature migration — no observable behavior change. The
+shipped `src/workflows/example_workflow.yml` (single `analysis` step, no
+`dependsOn`) is the right fixture for the smoke test; do not edit it.
+
+```bash
+npm install   # only on a fresh clone
+npm start
+# → Server is running at http://localhost:3000
+```
+
+The worker polls the queue every 5s; give the step that long to transition.
+
+### 1. Single-step workflow still runs end-to-end after the migration
+
+```bash
+curl -sS -X POST http://localhost:3000/analysis \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "clientId": "manual-test-3b-i",
+    "geoJson": {
+      "type": "Polygon",
+      "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]
+    }
+  }'
+# → 202 { "workflowId": "<uuid>", "message": "Workflow created..." }
+```
+
+Wait ~5s, then verify in `data/database.sqlite`:
+
+```bash
+sqlite3 data/database.sqlite \
+  "SELECT taskType, status, resultId FROM tasks WHERE clientId='manual-test-3b-i';"
+# → analysis, completed, <uuid>
+
+sqlite3 data/database.sqlite \
+  "SELECT data, error FROM results WHERE resultId IN (
+     SELECT resultId FROM tasks WHERE clientId='manual-test-3b-i'
+   );"
+# → data = '"<country name>"' (or '"No country found"'), error = (NULL)
+```
+
+Server logs include:
+
+```
+Starting job analysis for task <uuid>...
+Running data analysis for task <uuid>...
+Job analysis for task <uuid> completed successfully.
+```
+
+The single-step workflow reaches a terminal state exactly as it did before
+the migration — the task is marked `completed`, the linked `Result` row
+carries the same `data` payload, and no behavior depends on the
+`dependencies: []` envelope being passed through.
+
+### 2. Cleanup
+
+`AppDataSource` boots with `dropSchema: true`, so every restart wipes the DB.
+Nothing to revert — `example_workflow.yml` is left unchanged by this task.

--- a/src/jobs/DataAnalysisJob.test.ts
+++ b/src/jobs/DataAnalysisJob.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { DataAnalysisJob } from "./DataAnalysisJob";
+import type { Task } from "../models/Task";
+
+const makeTask = (geoJson: string): Task =>
+  ({
+    taskId: "task-under-test",
+    geoJson,
+    taskType: "analysis",
+  }) as Task;
+
+// Co-located unit test for DataAnalysisJob — exercises the new JobContext
+// signature mandated by PRD §Implementation Decision 5 / Issue #6 / Task 3b-i.
+
+describe("DataAnalysisJob — JobContext signature (PRD §Decision 5)", () => {
+  describe("happy path", () => {
+    it("returns 'No country found' for an equator-square polygon (ocean) using context.task", async () => {
+      // The job reads task.geoJson via context.task; for a polygon centered on
+      // (0,0)–(1,1) lat/lng (open ocean) the country lookup yields the
+      // documented "No country found" sentinel — behavior unchanged from the
+      // pre-3b-i implementation.
+      const job = new DataAnalysisJob();
+      const polygon = JSON.stringify({
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+      });
+      const result = await job.run({
+        task: makeTask(polygon),
+        dependencies: [],
+      });
+      expect(result).toBe("No country found");
+    });
+  });
+
+  describe("error path", () => {
+    it("throws when geoJson is not valid JSON", async () => {
+      // DataAnalysisJob calls JSON.parse(task.geoJson) directly, so malformed
+      // input must surface as a thrown error — the runner depends on this to
+      // mark the task failed.
+      const job = new DataAnalysisJob();
+      await expect(
+        job.run({ task: makeTask("not-json{"), dependencies: [] }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/jobs/DataAnalysisJob.ts
+++ b/src/jobs/DataAnalysisJob.ts
@@ -1,11 +1,11 @@
-import { Job } from './Job';
-import { Task } from '../models/Task';
+import { Job, JobContext } from './Job';
 import booleanWithin from '@turf/boolean-within';
 import { Feature, Polygon } from 'geojson';
 import countryMapping from '../data/world_data.json';
 
 export class DataAnalysisJob implements Job {
-    async run(task: Task): Promise<string> {
+    async run(context: JobContext): Promise<string> {
+        const { task } = context;
         console.log(`Running data analysis for task ${task.taskId}...`);
 
         const inputGeometry: Feature<Polygon> = JSON.parse(task.geoJson);

--- a/src/jobs/EmailNotificationJob.test.ts
+++ b/src/jobs/EmailNotificationJob.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { EmailNotificationJob } from "./EmailNotificationJob";
+import type { Task } from "../models/Task";
+
+const makeTask = (overrides: Partial<Task> = {}): Task =>
+  ({
+    taskId: "task-under-test",
+    taskType: "notification",
+    ...overrides,
+  }) as Task;
+
+// Co-located unit test for EmailNotificationJob — exercises the new JobContext
+// signature mandated by PRD §Implementation Decision 5 / Issue #6 / Task 3b-i.
+
+describe("EmailNotificationJob — JobContext signature (PRD §Decision 5)", () => {
+  describe("happy path", () => {
+    it("resolves successfully when called with { task, dependencies: [] }", async () => {
+      // 3b-i: notification is a no-op side-effect job; the only contract is
+      // that it resolves without throwing under the new signature.
+      const job = new EmailNotificationJob();
+      await expect(
+        job.run({ task: makeTask(), dependencies: [] }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("error path", () => {
+    it("does not crash when given a minimal task (defensive contract)", async () => {
+      // Defensive: even a near-empty task object must not break the job's
+      // signature contract — only the workflow runner is responsible for
+      // populating Task fields, the job itself must remain crash-free.
+      const job = new EmailNotificationJob();
+      const minimalTask = { taskId: "minimal" } as Task;
+      await expect(
+        job.run({ task: minimalTask, dependencies: [] }),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/jobs/EmailNotificationJob.ts
+++ b/src/jobs/EmailNotificationJob.ts
@@ -1,8 +1,8 @@
-import { Job } from './Job';
-import { Task } from '../models/Task';
+import { Job, JobContext } from './Job';
 
 export class EmailNotificationJob implements Job {
-    async run(task: Task): Promise<void> {
+    async run(context: JobContext): Promise<void> {
+        const { task } = context;
         console.log(`Sending email notification for task ${task.taskId}...`);
         // Perform notification work
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/src/jobs/Job.ts
+++ b/src/jobs/Job.ts
@@ -1,6 +1,17 @@
-import {Task} from "../models/Task";
+import { Task } from "../models/Task";
 
+export interface JobDependencyOutput {
+    stepNumber: number;
+    taskType: string;
+    taskId: string;
+    output: unknown;
+}
+
+export interface JobContext {
+    task: Task;
+    dependencies: JobDependencyOutput[];
+}
 
 export interface Job {
-    run(task: Task): Promise<any>;
+    run(context: JobContext): Promise<unknown>;
 }

--- a/src/jobs/PolygonAreaJob.test.ts
+++ b/src/jobs/PolygonAreaJob.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { PolygonAreaJob } from "./PolygonAreaJob";
+import type { Task } from "../models/Task";
+
+const makeTask = (geoJson: string): Task =>
+  ({
+    taskId: "task-under-test",
+    geoJson,
+    taskType: "polygonArea",
+  }) as Task;
+
+const VALID_POLYGON_JSON = JSON.stringify({
+  type: "Polygon",
+  coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+});
+
+// Co-located unit test for PolygonAreaJob — exercises the new JobContext
+// signature mandated by PRD §Implementation Decision 5 / Issue #6 / Task 3b-i.
+
+describe("PolygonAreaJob — JobContext signature (PRD §Decision 5)", () => {
+  describe("happy path", () => {
+    it("computes areaSqMeters from context.task, ignoring dependencies", async () => {
+      // The job must read inputs from context.task and ignore the dependencies
+      // envelope — 3b-i is a pure signature migration with zero behavior change.
+      const job = new PolygonAreaJob();
+      const result = await job.run({
+        task: makeTask(VALID_POLYGON_JSON),
+        dependencies: [],
+      });
+      expect(result.areaSqMeters).toBeGreaterThan(1.2e10);
+      expect(result.areaSqMeters).toBeLessThan(1.3e10);
+    });
+
+    it("produces the same output when dependencies is non-empty (envelope is ignored)", async () => {
+      // Defensive assertion: 3b-ii will start populating dependencies, but
+      // 3b-i jobs must be insensitive to its contents.
+      const job = new PolygonAreaJob();
+      const withEmpty = await job.run({
+        task: makeTask(VALID_POLYGON_JSON),
+        dependencies: [],
+      });
+      const withSomething = await job.run({
+        task: makeTask(VALID_POLYGON_JSON),
+        dependencies: [
+          { stepNumber: 1, taskType: "analysis", taskId: "x", output: "noise" },
+        ],
+      });
+      expect(withSomething.areaSqMeters).toBe(withEmpty.areaSqMeters);
+    });
+  });
+
+  describe("error path", () => {
+    it("throws a descriptive Error for invalid (non-JSON) GeoJSON", async () => {
+      const job = new PolygonAreaJob();
+      await expect(
+        job.run({ task: makeTask("not-json{"), dependencies: [] }),
+      ).rejects.toThrow(/Invalid GeoJSON|parse/i);
+    });
+  });
+});

--- a/src/jobs/PolygonAreaJob.ts
+++ b/src/jobs/PolygonAreaJob.ts
@@ -1,6 +1,6 @@
 import area from "@turf/area";
 import type { Feature, Geometry, Polygon } from "geojson";
-import type { Job } from "./Job";
+import type { Job, JobContext } from "./Job";
 import type { Task } from "../models/Task";
 
 type GenericFeature = Feature<Geometry | null>;
@@ -21,7 +21,8 @@ export enum PolygonAreaJobValidationError {
 }
 
 export class PolygonAreaJob implements Job {
-  async run(task: Task): Promise<PolygonAreaResult> {
+  async run(context: JobContext): Promise<PolygonAreaResult> {
+    const { task } = context;
     const validationError = this.validate(task);
     if (validationError) {
       throw new Error(`Invalid GeoJSON (Polygon expected): ${validationError}`);

--- a/src/workers/taskRunner.test.ts
+++ b/src/workers/taskRunner.test.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DataSource } from "typeorm";
+import { TaskRunner, TaskStatus } from "./taskRunner";
+import { Task } from "../models/Task";
+import { Result } from "../models/Result";
+import { Workflow } from "../models/Workflow";
+import { WorkflowStatus } from "../workflows/WorkflowFactory";
+import type { Job } from "../jobs/Job";
+
+// Module under test injects its job via `getJobForTaskType`. We mock that
+// boundary so the runner unit test can install a spy job and assert the
+// JobContext envelope it receives.
+const getJobMock = vi.hoisted(() => vi.fn());
+vi.mock("../jobs/JobFactory", () => ({
+  getJobForTaskType: getJobMock,
+}));
+
+const buildDataSource = (): DataSource =>
+  new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    dropSchema: true,
+    entities: [Task, Result, Workflow],
+    synchronize: true,
+    logging: false,
+  });
+
+async function seedTask(dataSource: DataSource): Promise<Task> {
+  const workflowRepository = dataSource.getRepository(Workflow);
+  const taskRepository = dataSource.getRepository(Task);
+  const workflow = await workflowRepository.save(
+    Object.assign(new Workflow(), {
+      clientId: "c1",
+      status: WorkflowStatus.Initial,
+    }),
+  );
+  return taskRepository.save(
+    Object.assign(new Task(), {
+      clientId: "c1",
+      geoJson: "{}",
+      status: TaskStatus.Queued,
+      taskType: "polygonArea",
+      stepNumber: 1,
+      workflow,
+    }),
+  );
+}
+
+describe("TaskRunner — passes JobContext to job.run (PRD §Decision 5)", () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = buildDataSource();
+    await dataSource.initialize();
+    getJobMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataSource.isInitialized) await dataSource.destroy();
+  });
+
+  describe("happy path", () => {
+    it("calls job.run with an object containing { task, dependencies: [] } and persists Result", async () => {
+      // Spy job records its call argument. The runner must invoke
+      // job.run({ task, dependencies: [] }) — task is the seeded entity,
+      // dependencies is an empty array (3b-i scope: no envelope yet).
+      const runArgs: unknown[] = [];
+      const spyJob: Job = {
+        run: async (context: unknown) => {
+          runArgs.push(context);
+          return { ok: true };
+        },
+      };
+      getJobMock.mockReturnValue(spyJob);
+
+      const task = await seedTask(dataSource);
+      const runner = new TaskRunner(dataSource.getRepository(Task));
+      await runner.run(task);
+
+      expect(runArgs).toHaveLength(1);
+      const arg = runArgs[0] as { task: Task; dependencies: unknown[] };
+      expect(arg.task.taskId).toBe(task.taskId);
+      expect(arg.dependencies).toEqual([]);
+
+      const refreshed = await dataSource
+        .getRepository(Task)
+        .findOneOrFail({ where: { taskId: task.taskId } });
+      expect(refreshed.status).toBe(TaskStatus.Completed);
+    });
+  });
+
+  describe("error path", () => {
+    it("when the spy job throws, marks the task Failed and rethrows", async () => {
+      // The runner contract: a job throw must persist a structured
+      // Result.error and surface a Failed task status. The spy throws so we
+      // can verify the runner does not silently swallow the error and that
+      // the new signature plumbs failures through unchanged.
+      const failingJob: Job = {
+        run: async () => {
+          throw new Error("boom");
+        },
+      };
+      getJobMock.mockReturnValue(failingJob);
+
+      const task = await seedTask(dataSource);
+      const runner = new TaskRunner(dataSource.getRepository(Task));
+      await expect(runner.run(task)).rejects.toThrow(/boom/);
+
+      const refreshed = await dataSource
+        .getRepository(Task)
+        .findOneOrFail({ where: { taskId: task.taskId } });
+      expect(refreshed.status).toBe(TaskStatus.Failed);
+      expect(refreshed.resultId).toBeTruthy();
+    });
+  });
+});

--- a/src/workers/taskRunner.ts
+++ b/src/workers/taskRunner.ts
@@ -33,7 +33,7 @@ export class TaskRunner {
 
         try {
             console.log(`Starting job ${task.taskType} for task ${task.taskId}...`);
-            const taskResult = await job.run(task);
+            const taskResult = await job.run({ task, dependencies: [] });
             console.log(`Job ${task.taskType} for task ${task.taskId} completed successfully.`);
 
             await this.taskRepository.manager.transaction(async (entityManager) => {

--- a/tests/01-polygon-area/handles-invalid-geojson-gracefully.test.ts
+++ b/tests/01-polygon-area/handles-invalid-geojson-gracefully.test.ts
@@ -41,17 +41,17 @@ describe("Readme §1 R2 — handles invalid GeoJSON gracefully and marks the tas
   describe("marks the task failed and persists structured Result.error on invalid GeoJSON", () => {
     it("PolygonAreaJob throws a descriptive Error when geoJson is not valid JSON", async () => {
       const job = new PolygonAreaJob();
-      await expect(job.run(makeTask("not-valid-json{"))).rejects.toThrow(
-        /Invalid GeoJSON|parse/i,
-      );
+      await expect(
+        job.run({ task: makeTask("not-valid-json{"), dependencies: [] }),
+      ).rejects.toThrow(/Invalid GeoJSON|parse/i);
     });
 
     it("PolygonAreaJob throws when the GeoJSON is not a Polygon (e.g. Point)", async () => {
       const point = { type: "Point", coordinates: [0, 0] };
       const job = new PolygonAreaJob();
-      await expect(job.run(makeTask(JSON.stringify(point)))).rejects.toThrow(
-        /Polygon/,
-      );
+      await expect(
+        job.run({ task: makeTask(JSON.stringify(point)), dependencies: [] }),
+      ).rejects.toThrow(/Polygon/);
     });
 
     describe("runner-level persistence", () => {

--- a/tests/01-polygon-area/outputs-area-in-square-meters.test.ts
+++ b/tests/01-polygon-area/outputs-area-in-square-meters.test.ts
@@ -73,7 +73,7 @@ describe("Readme §1 R1 — output includes the calculated area in square meters
       };
       const job = new PolygonAreaJob();
 
-      const result = await job.run(makeTask(JSON.stringify(polygon)));
+      const result = await job.run({ task: makeTask(JSON.stringify(polygon)), dependencies: [] });
 
       // @turf/area returns ~12,363,718,145 m² for this square. Assert a tolerant
       // range rather than an exact float so the test isn't brittle to library
@@ -92,7 +92,7 @@ describe("Readme §1 R1 — output includes the calculated area in square meters
         },
       };
       const job = new PolygonAreaJob();
-      const result = await job.run(makeTask(JSON.stringify(feature)));
+      const result = await job.run({ task: makeTask(JSON.stringify(feature)), dependencies: [] });
       expect(result.areaSqMeters).toBeGreaterThan(1.2e10);
     });
 
@@ -151,7 +151,7 @@ describe("Readme §1 R1 — output includes the calculated area in square meters
         coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]],
       };
       const job = new PolygonAreaJob();
-      const result = await job.run(makeTask(JSON.stringify(degenerate)));
+      const result = await job.run({ task: makeTask(JSON.stringify(degenerate)), dependencies: [] });
       expect(result.areaSqMeters).toBe(0);
     });
   });


### PR DESCRIPTION
Closes #6.

## Summary

Pure mechanical refactor of `Job.run(task)` → `Job.run({ task, dependencies })` per **PRD §Implementation Decision 5**. No observable behavior change. `dependencies` is always `[]` until #7 lands the runtime envelope builder.

## What changed

- `src/jobs/Job.ts` — interface migrated to `run(context: JobContext): Promise<unknown>`; exports `JobContext` and `JobDependencyOutput` types with the PRD §Decision 5 shape `{ task: Task; dependencies: { stepNumber: number; taskType: string; taskId: string; output: unknown }[] }`.
- `src/jobs/{PolygonArea,DataAnalysis,EmailNotification}Job.ts` — all migrated to the new signature; read inputs from `context.task`; ignore `context.dependencies`.
- `src/workers/taskRunner.ts` — single-line change: constructs `{ task, dependencies: [] }` and passes it to `job.run`. Workflow-lifecycle code at the bottom is byte-identical.

## Test strategy

The test-strategy section in #6 was written before `CLAUDE.md` was updated to require unit tests co-located with source (commit `b62513a`). The spec note in this workspace was the canonical plan, agreed with the reviewer before delegation.

- **New co-located unit tests** (per the updated `CLAUDE.md`):
  - `src/jobs/PolygonAreaJob.test.ts`
  - `src/jobs/DataAnalysisJob.test.ts`
  - `src/jobs/EmailNotificationJob.test.ts`
  - `src/workers/taskRunner.test.ts`
  - Each follows the happy-path + ≥1 error-path describe-block layout, with inline comments where >10 lines.
- **Integration files preserved.** `tests/01-polygon-area/*.test.ts` updated only at `job.run(...)` call sites — no new describe blocks. `tests/03-interdependent-tasks/tasks-can-be-chained-through-dependencies.test.ts` had no direct `job.run(...)` call sites (it exercises workflow-level paths) and was not modified.
- **Pre-existing `tests/03-interdependent-tasks/*.unit.test.ts` left untouched.** Migrating those four files to a co-located location is a separate cleanup task, explicitly out of scope here.

## Quality gates

- `npm run lint` → exit 0
- `npm run typecheck` → exit 0
- `npm test` → 51 passing across 12 files
- Pre-push hook ran on push: lint + full Vitest suite, both green.
- One conventional commit (`9316890`); body references PRD §Decision 5 and Issue #6. No `--no-verify`.

## Manual verification

`interview/manual_test_plan.md` has a new §Task 3b-i section with curl + sqlite verification steps confirming a single-step workflow runs end-to-end after the migration.

## Out of scope (next slice)

- Runtime promotion of `waiting → queued`, dependency envelope builder, fail-fast sweep, workflow lifecycle transitions → **Issue #7 (Task 3b-ii)**, now unblocked by this PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author